### PR TITLE
Alerts for low disk space

### DIFF
--- a/plugins/state_monitor.py
+++ b/plugins/state_monitor.py
@@ -51,6 +51,9 @@ class StateMonitor(brokkr.pipeline.base.OutputStep):
             The chat channel in which to post notifications.
         key_file : str or pathlib.Path, optional
             The path to the file that contains the secret/webhook key for the given `method`.
+        low_pi_space: numeric, optional
+            Specifies the critical value, in gigabytes-ish, for hard drive space remaining
+            on the backend Pi.
         output_step_kwargs : **kwargs, optional
             Keyword arguments to pass to the OutputStep constructor.
 
@@ -185,7 +188,7 @@ class StateMonitor(brokkr.pipeline.base.OutputStep):
 
         """
         for check_fn in [
-                self.check_drive, 
+                self.check_drive,
                 self.check_pi_space,
                 self.check_ping,
                 self.check_power,
@@ -229,7 +232,7 @@ class StateMonitor(brokkr.pipeline.base.OutputStep):
             return None
 
     def check_drive(self, input_data):
-
+        """Check to see if the archive drive is available"""
         from brokkr.config.main import CONFIG
         import brokkr.utils.output
         drive_settings = CONFIG['steps']['science_binary_output']['drive_kwargs']

--- a/plugins/state_monitor.py
+++ b/plugins/state_monitor.py
@@ -26,7 +26,7 @@ class StateMonitor(brokkr.pipeline.base.OutputStep):
         ping_max=3,
         channel=None,
         key_file=None,
-        low_pi_space=5e9,
+        low_pi_space=5,
         **output_step_kwargs,
         ):
         """
@@ -68,7 +68,7 @@ class StateMonitor(brokkr.pipeline.base.OutputStep):
         self.ping_max = ping_max
         self.bad_ping = 0  # Track the number of bad pings
         self.sender = None  # Make sure we "initialize" the attribute
-        self.low_pi_space = low_pi_space
+        self.low_pi_space = low_pi_space*1000000000
 
         sender_class = {"slack": SlackSender, "gchat": GoogleChatSender}[method]
         try:


### PR DESCRIPTION
Add alerts for low disk space on the backend Pi (if it fills, we usually can't get back in) and if brokkr can't find the hard drives which fixes (which often causes the former). These fix HAM-4 and HAM-42 respectively.